### PR TITLE
Fix emergency contact phone placeholder typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
                             type="tel"
                             id="emergency-phone"
                             name="emergency-phone"
-                            placeholder="phone numer"
+                            placeholder="phone number"
                             required />
                     </div>
                     <div class="other-details">


### PR DESCRIPTION
## Summary
- Correct emergency contact phone field placeholder typo to read "phone number"

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_689717ba2978832faa3899e21df2f5e0