### PR TITLE
Make medical history form responsive with updated backgrounds

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,34 @@
+body {
+    margin: 0;
+    padding: 0;
+    background-color: #e6f0ff;
+    font-family: Arial, Helvetica, sans-serif;
+}
+
+form {
+    max-width: 800px;
+    margin: 1rem auto;
+    background-color: #ffffff;
+    padding: 1rem;
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}
+
+section {
+    margin-bottom: 1rem;
+}
+
+input[type="text"],
+input[type="date"],
+input[type="email"],
+input[type="tel"],
+textarea,
+select {
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+}
+
 .title {
     color: green;
 }
@@ -54,6 +85,21 @@
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
+}
+
+@media (min-width: 600px) {
+    .row {
+        flex-direction: row;
+        align-items: center;
+    }
+    .row label {
+        flex: 1;
+    }
+    .row input,
+    .row textarea,
+    .row select {
+        flex: 2;
+    }
 }
 
 


### PR DESCRIPTION
## Summary
- Add blue body background and white card styling for the form
- Ensure inputs span the full width and add media query for larger screens

## Testing
- `npm test` *(fails: ENOENT, package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689721afd0f8832faebc673202982970